### PR TITLE
Made inventory grid cilckable

### DIFF
--- a/Scripts/Global.gd
+++ b/Scripts/Global.gd
@@ -2,6 +2,7 @@ extends Node
 
 signal player_health_changed
 signal inventory_updated
+signal inventory_cell_pressed
 
 var player_health: float = 100.0
 

--- a/UI/Inventory/inventory_panel.gd
+++ b/UI/Inventory/inventory_panel.gd
@@ -1,0 +1,15 @@
+extends Button
+
+@export var options_scene: PackedScene
+
+func _ready() -> void:
+	pressed.connect(on_press)
+
+func on_press():
+	var options = get_parent().get_parent().get_node("ItemOptions")
+	if not options and options_scene:
+		var new_options = options_scene.instantiate()
+		new_options.position = global_position + Vector2(80, 80)
+		get_parent().get_parent().add_child(new_options)
+	else:
+		options.position = global_position + Vector2(80, 80)

--- a/UI/Inventory/inventory_panel.gd.uid
+++ b/UI/Inventory/inventory_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://ck35bbyasfki4

--- a/UI/Inventory/inventory_panel.tscn
+++ b/UI/Inventory/inventory_panel.tscn
@@ -1,7 +1,14 @@
-[gd_scene format=3 uid="uid://5k6quq3huxb6"]
+[gd_scene load_steps=3 format=3 uid="uid://5k6quq3huxb6"]
 
-[node name="InventoryPanel" type="Panel"]
+[ext_resource type="Script" uid="uid://ck35bbyasfki4" path="res://UI/Inventory/inventory_panel.gd" id="1_pp364"]
+[ext_resource type="PackedScene" uid="uid://b6vtj8lolwlg0" path="res://UI/Inventory/item_options.tscn" id="2_qh4c2"]
+
+[node name="InventoryPanel" type="Button"]
 custom_minimum_size = Vector2(128, 128)
+offset_right = 128.0
+offset_bottom = 128.0
+script = ExtResource("1_pp364")
+options_scene = ExtResource("2_qh4c2")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 1

--- a/UI/Inventory/item_options.tscn
+++ b/UI/Inventory/item_options.tscn
@@ -1,0 +1,18 @@
+[gd_scene format=3 uid="uid://b6vtj8lolwlg0"]
+
+[node name="ItemOptions" type="VBoxContainer"]
+z_index = 200
+offset_right = 146.0
+offset_bottom = 93.0
+
+[node name="Use" type="Button" parent="."]
+z_index = 300
+layout_mode = 2
+size_flags_vertical = 3
+text = "Use"
+
+[node name="Throw" type="Button" parent="."]
+z_index = 300
+layout_mode = 2
+size_flags_vertical = 3
+text = "Throw"

--- a/UI/hud.tscn
+++ b/UI/hud.tscn
@@ -5,8 +5,7 @@
 
 [node name="HUD" type="Control" node_paths=PackedStringArray("health_bar")]
 visible = false
-z_index = 4096
-z_as_relative = false
+z_index = 100
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an item options menu with "Use" and "Throw" buttons accessible from the inventory panel.
- **Improvements**
	- Inventory panel is now interactive, allowing users to open item options by pressing on items.
- **UI Changes**
	- Inventory panel updated to be a button for improved interactivity.
	- Adjusted HUD layering to improve display order of UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->